### PR TITLE
Move size() from setup() to settings() as per https://github.com/proc…

### DIFF
--- a/evolutionSteer.pde
+++ b/evolutionSteer.pde
@@ -850,6 +850,9 @@ void drawStatusWindow(boolean isFirstFrame) {
     }
   }
 }
+void settings() {
+  size((int)(windowWidth*windowSizeMultiplier), (int)(windowHeight*windowSizeMultiplier),P3D);
+}
 void setup() {
   String[] prePatronData = loadStrings("PatronReport_2017-06-12.csv");
   patronData = new String[PATRON_COUNT];
@@ -866,7 +869,6 @@ void setup() {
   frameRate(60);
   randomSeed(SEED);
   noSmooth();
-  size((int)(windowWidth*windowSizeMultiplier), (int)(windowHeight*windowSizeMultiplier),P3D);
   ellipseMode(CENTER);
   Float[] beginPercentile = new Float[29];
   Integer[] beginBar = new Integer[barLen];


### PR DESCRIPTION
When I tried to run the evolutionSteer it complained with this error "size() cannot be used here, see https://processing.org/reference/size_.html" so  moving the size() call to settings() seems to have fixed this.