### PR TITLE
Add extra neuron for heartbeat, add heartbeat for continuous motion

### DIFF
--- a/Brain.pde
+++ b/Brain.pde
@@ -1,4 +1,7 @@
 class Brain {
+  float heartbeatStrength = 10;
+  float heartbeatInterval = 0.1;
+  float timesUsed = 0;
   float[][] neurons;
   Axon[][][] axons;
   int BRAIN_WIDTH = 0;
@@ -86,10 +89,16 @@ class Brain {
   public void useBrain(Creature owner){
     ArrayList<Node> n = owner.n;
     ArrayList<Muscle> m = owner.m;
-    for(int i = 0; i < n.size(); i++){
-      Node ni = n.get(i);
+    
+    for(int i = 1; i < n.size(); i++){
+      Node ni = n.get(i - 1);
       neurons[0][i] = dist(ni.x, ni.y, ni.z, foodX, foodY, foodZ);
     }
+    
+    neurons[0][0] = ((sin(timesUsed) / 2) + 0.5) * heartbeatStrength;
+    
+    timesUsed += heartbeatInterval;
+    
     for(int i = 0; i < m.size(); i++){
       Muscle am = m.get(i);
       Node ni1 = n.get(am.c1);

--- a/Creature.pde
+++ b/Creature.pde
@@ -44,7 +44,7 @@ class Creature {
     }
   }
   int getBrainHeight(){
-    return n.size()+m.size()+1;
+    return n.size()+m.size()+2;
   }
   void changeBrainStructure(int rowInsertionIndex, int rowRemovalIndex){
     brain.changeBrainStructure(BRAIN_WIDTH, getBrainHeight(), rowInsertionIndex,rowRemovalIndex);


### PR DESCRIPTION
In the video, you can see that only using the distance from a node to the food will cause the input to never change once the creature is stationary. Only some twitching will cause a creature to keep moving, which is an unintentional side-effect of the physics engine.

Creating an extra node with a "heartbeat" will cause the input to constantly fluctuate, which gives the brain something to grab a hold of for continuous movement.

Tested locally to approx. gen 100, and already interesting results can be seen, with creatures almost walking, in a sense.

Note: Due to how the brain is created, this also causes an extra unneccesary neuron to be created in the output layer, but this should be harmless. I'm not completely familiar with the neural network code though, and this might require checking to make sure.